### PR TITLE
removed purrr dependency due to `modify_depth` failures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-  R6,
-  purrr
+  R6
 Suggests:
   covr,
   testthat

--- a/R/class_utilities.R
+++ b/R/class_utilities.R
@@ -60,9 +60,9 @@ within_boundaries = function(simplex, names, boundaries){
   #' @param boundaries list of treatment boundaries
   #'
   #' @return logical indicating if all values are within boundaries
-  all(purrr::map_lgl(seq_along(names), function(i){
-    all(simplex[[names[[i]]]] %between% boundaries[[i]])
-  }))
+  check = vapply(seq_along(names), function(i){all(simplex[[names[[i]]]] %between% boundaries[[i]])}, #nolint
+                 FUN.VALUE = logical(1))
+  all(check)
 }
 
 
@@ -74,7 +74,7 @@ satisfied_constraints = function(simplex, constraints){
   #'
   #' @return logical indicating if all constraints are met
   if (length(constraints) == 0) return(TRUE)
-  purrr::map_lgl(constraints, function(expr) all(with(simplex, expr = eval(expr))))
+  vapply(constraints, function(expr) all(with(simplex, expr = eval(expr))), FUN.VALUE = logical(1))
 }
 
 

--- a/R/execute_experiment.R
+++ b/R/execute_experiment.R
@@ -33,12 +33,10 @@ submit_responses = function(data = NULL){
     if (!identical(c("Vertex_ID", responses), names(data))){
       stop("Input data must have exactly 'Vertex_ID' and each response")
     }
-    if (any(purrr::map_lgl(data, function(x) any(is.na(x)) | any(!is.numeric(x))))){
+    if (any(vapply(data, function(x) any(is.na(x)) | any(!is.numeric(x)), FUN.VALUE = logical(1)))){
       stop("Input data must have a numeric value for each response.")
     }
-    purrr::map_lgl(responses, function(j){
-      check_response_range(data[[j]], self$responses, j)
-    })
+    vapply(responses, function(j){check_response_range(data[[j]], self$responses, j)}, FUN.VALUE = logical(1)) #nolint
     new_rows = merge(current[c("Vertex_ID", treatments)], data, by = "Vertex_ID")
     old_rows = current[!current[["Vertex_ID"]] %in% new_rows[["Vertex_ID"]], ]
     self$simplexes[[n]] = rbind(old_rows, new_rows)

--- a/R/setup_experiment.R
+++ b/R/setup_experiment.R
@@ -144,7 +144,7 @@ generate_initial_simplex = function(method = "manual", data = NULL){
   treatments = names(self$treatments)
   responses = names(self$responses)
   k = self$k
-  boundaries = lapply(self$treatments, function(x){x[["boundaries"]]})
+  boundaries = lapply(self$treatments, function(x){x[["boundaries"]]}) #nolint
 
   if (method == "manual"){
     if (!all(treatments %in% names(data))) stop("Not all treatments are included in the initial simplex")


### PR DESCRIPTION
Due to version differences in development environments and failure to resolve an apparent issue with the use of `modify_depth`, this PR is to remove the dependency on purrr. All existing `map_lgl` are easily replaced with `vapply` statements.